### PR TITLE
docs: more accurate typing for vim.tbl_extend

### DIFF
--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -374,7 +374,7 @@ end
 ---
 ---@see |extend()|
 ---
----@param behavior string Decides what to do if a key is found in more than one map:
+---@param behavior "error"|"keep"|"force" (string) Decides what to do if a key is found in more than one map:
 ---      - "error": raise an error
 ---      - "keep":  use value from the leftmost map
 ---      - "force": use value from the rightmost map


### PR DESCRIPTION
Matches the type signatures of `vim.tbl_extend` to `vim.tbl_deep_extend` (namely, it specifies the enum values of the first parameter in the actual signature, rather than just in the parameter's description).